### PR TITLE
Add the "declare" portion of a trigger as a top-level attribute

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -12,20 +12,20 @@ DELETE, TRUNCATE) on certain conditions of the affected rows.
 
 The `pgtrigger.Trigger` object is the base class for all triggers.
 Attributes of this class mirror the syntax required for
-`making a Postgres trigger <https://www.postgresql.org/docs/current/sql-createtrigger.html>`__,
-and one has the ability to input the exact
-`PL/pgSQL code <https://www.postgresql.org/docs/current/plpgsql.html>`__
-that is executed by Postgres in the trigger. ``pgtrigger`` also has several
-helper classes, like `pgtrigger.Protect`, that implement some core
-triggers you can configure without having to write ``PL/pgSQL``
-syntax.
+`making a Postgres trigger <https://www.postgresql.org/docs/current/sql-createtrigger.html>`__.
 
-When declaring a trigger, one can provide the following core attributes:
+The ``django-pgtrigger`` library is designed so that users only need to use
+Python and Django idioms for registering common triggers on models.
+More advanced users, however, can always
+directly write the raw PL/pgSQL dialect used for Postgres triggers.
+
+Here are all of basic attributes of triggers that you will use when
+using just about any of the triggers in this library:
 
 * **name**
 
     The identifying name of trigger. Is unique for every model and must
-    be less than 53 characters. The trigger name is used for
+    be <= 47 characters. The trigger name is used for
     performing trigger management operations and must be provided.
 
 * **when**
@@ -91,11 +91,28 @@ When declaring a trigger, one can provide the following core attributes:
         One must keep these caveats in mind when constructing triggers
         to avoid unexpected behavior.
 
-* **name** *(optional)*
 
-    Registers the trigger with a human-readable name so that it can
-    be referenced in other ``django-pgtrigger`` functionality
-    such as `pgtrigger.ignore`.
+Here are the more advanced attributes of triggers that you will want to
+know about when writing more complex triggers or writing your own
+trigger functions.
+
+
+* **func**
+
+    The raw PL/pgSQL function that is executed.
+
+
+    .. note::
+
+        This is *not* the entire declared trigger function, but rather
+        the snippet of PL/pgSQL that is nested in the
+        ```DECLARE ... BEGIN ... END``` portion of the trigger.
+
+* **declare** *(optional)*
+
+    If the trigger requires additional variable declarations, they
+    can be defined as a list of (variable_name, variable_type) tuples.
+    For example ``declare=[('my_var_1', 'BOOLEAN'), ('my_var_2', 'JSONB')]``
 
 * **level** *(optional, default=pgtrigger.Row)*
 

--- a/pgtrigger/__init__.py
+++ b/pgtrigger/__init__.py
@@ -1,3 +1,5 @@
+import django
+
 from pgtrigger.core import After
 from pgtrigger.core import Before
 from pgtrigger.core import Condition
@@ -27,7 +29,10 @@ from pgtrigger.core import uninstall
 from pgtrigger.core import Update
 from pgtrigger.core import UpdateOf
 
-default_app_config = 'pgtrigger.apps.PGTriggerConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'pgtrigger.apps.PGTriggerConfig'
+
+del django
 
 
 __all__ = [

--- a/pgtrigger/core.py
+++ b/pgtrigger/core.py
@@ -393,6 +393,7 @@ class Trigger:
     condition = None
     referencing = None
     func = None
+    declare = None
 
     def __init__(
         self,
@@ -404,6 +405,7 @@ class Trigger:
         condition=None,
         referencing=None,
         func=None,
+        declare=None,
     ):
         self.name = name or self.name
         self.level = level or self.level
@@ -412,6 +414,7 @@ class Trigger:
         self.condition = condition or self.condition
         self.referencing = referencing or self.referencing
         self.func = func or self.func
+        self.declare = declare or self.declare
 
         if not self.level or not isinstance(self.level, _Level):
             raise ValueError(f'Invalid "level" attribute: {self.level}')
@@ -472,7 +475,7 @@ class Trigger:
             List[tuple]: A list of variable name / type tuples that will
             be shown in the DECLARE. For example [('row_data', 'JSONB')]
         """
-        return []
+        return self.declare or []
 
     def get_func(self, model):
         """

--- a/pgtrigger/tests/test_core.py
+++ b/pgtrigger/tests/test_core.py
@@ -293,13 +293,13 @@ def test_max_name_length(mocker):
     )
     assert trigger.get_pgid(models.TestTrigger)
 
-    with mocker.patch.object(pgtrigger.Protect, 'validate_name'):
-        with pytest.raises(ValueError):
-            trigger = pgtrigger.Protect(
-                name='a' * (pgtrigger.core.MAX_NAME_LENGTH + 1),
-                operation=pgtrigger.Update,
-            )
-            trigger.get_pgid(models.TestTrigger)
+    mocker.patch.object(pgtrigger.Protect, 'validate_name')
+    with pytest.raises(ValueError):
+        trigger = pgtrigger.Protect(
+            name='a' * (pgtrigger.core.MAX_NAME_LENGTH + 1),
+            operation=pgtrigger.Update,
+        )
+        trigger.get_pgid(models.TestTrigger)
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Previously one had to subclass a trigger and override ``get_declare`` in
order to change how the "DECLARE" fragment of a trigger was rendered.
Users can now provide ``declare`` to the instantiation of a trigger.

The documentation was updated to reflect this change.

Type: feature