### PR TITLE
Ensure that generated postgres IDs are lowercase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,12 @@ in a ``pgtrigger.Trigger`` object or can use the derived triggers in
     import pgtrigger
 
 
-    @pgtrigger.register(pgtrigger.Protect(operation=pgtrigger.Delete))
+    @pgtrigger.register(
+        pgtrigger.Protect(
+            name='protect_deletes',
+            operation=pgtrigger.Delete
+        )
+    )
     class CannotBeDeletedModel(models.Model):
         """This model cannot be deleted!"""
 
@@ -62,6 +67,7 @@ against "active" rows of a model:
 
     @pgtrigger.register(
         pgtrigger.Protect(
+            name='conditional_deletion_protection',
             operation=pgtrigger.Delete,
             # Protect deletes when the OLD row of the trigger is still active
             condition=pgtrigger.Q(old__is_active=True)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -518,6 +518,7 @@ we want to freeze once it is published:
 
     @pgtrigger.register(
         pgtrigger.Protect(
+            name='freeze_published_model',
             operation=pgtrigger.Update,
             condition=pgtrigger.Q(old__status='published')
         )
@@ -543,6 +544,7 @@ We can change the condition a bit more to allow this:
 
     @pgtrigger.register(
         pgtrigger.Protect(
+            name='freeze_published_model_allow_deactivation',
             operation=pgtrigger.Update,
             condition=(
               pgtrigger.Q(old__status='published')

--- a/pgtrigger/core.py
+++ b/pgtrigger/core.py
@@ -461,7 +461,10 @@ class Trigger:
                 f'Trigger identifier "{pgid}" is greater than 63 chars'
             )
 
-        return pgid
+        # NOTE - Postgres always stores names in lowercase. Ensure that all
+        # generated IDs are lowercase so that we can properly do installation
+        # and pruning tasks.
+        return pgid.lower()
 
     def get_condition(self, model):
         return self.condition
@@ -505,18 +508,16 @@ class Trigger:
 
         for model in models:
             uri = self.get_uri(model)
-            if uri in registry:  # pragma: no cover
+            if uri in registry:
                 raise ValueError(
                     f'Trigger with name "{self.name}" is already'
                     f' registered for model "{model}"'
                 )
 
-            if (
-                self.get_pgid(model) in registered_function_names
-            ):  # pragma: no cover
+            if self.get_pgid(model) in registered_function_names:
                 raise ValueError(
                     f'Trigger with name "{self.name}" on model "{model}"'
-                    ' has an trigger function name that is already taken.'
+                    ' has a trigger function name that is already taken.'
                     ' Use a different name for the trigger.'
                 )
 


### PR DESCRIPTION
django-pgtrigger now ensures that generated postgres IDs are
lowercase. Postgres IDs are case insensitive, and it django-pgtrigger
had issues dealing with names that had a mix of cases.

Type: bug