### PR TITLE
Triggers can be specified in model Meta options plus other fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,3 +131,4 @@ Other Contributors
 ==================
 
 - @jzmiller1
+- @rrauenza

--- a/README.rst
+++ b/README.rst
@@ -25,17 +25,17 @@ solve in the docs:
 Quick Start
 ===========
 
-Install ``django-pgtrigger`` with ``pip install django-pgtrigger`` and
+Install ``django-pgtrigger`` with ``pip3 install django-pgtrigger`` and
 add ``pgtrigger`` to ``settings.INSTALLED_APPS``.
 
-Models are decorated with ``@pgtrigger.register`` and supplied with
-``pgtrigger.Trigger`` objects. If you don't have access to the model definition,
+Triggers are declared in the ``triggers`` attribute of the model ``Meta``.
+If you don't have access to the model definition,
 you can still call ``pgtrigger.register`` programmatically.
 
-Users declare the plpgsql code manually
-in a ``pgtrigger.Trigger`` object or can use the derived triggers in
-``django-pgtrigger`` that implement common scenarios. For example,
-``pgtrigger.Protect`` can protect operations on a model, such as deletions:
+Users declare the PL/pgSQL code
+in a ``pgtrigger.Trigger`` object or use the derived triggers in
+``django-pgtrigger`` for common scenarios. For example,
+``pgtrigger.Protect`` protects operations on a model, such as deletions:
 
 .. code-block:: python
 
@@ -43,21 +43,20 @@ in a ``pgtrigger.Trigger`` object or can use the derived triggers in
     import pgtrigger
 
 
-    @pgtrigger.register(
-        pgtrigger.Protect(
-            name='protect_deletes',
-            operation=pgtrigger.Delete
-        )
-    )
     class CannotBeDeletedModel(models.Model):
         """This model cannot be deleted!"""
 
-``django-pgtrigger`` aims to alleviate the boilerplate of triggers and
-having to write raw SQL by using common Django idioms. For example, users
-can use ``pgtrigger.Q`` and ``pgtrigger.F`` objects to
+        class Meta:
+            triggers = [
+                pgtrigger.Protect(name='protect_deletes', operation=pgtrigger.Delete)
+            ]
+
+``django-pgtrigger`` implements common Django idioms.
+For example, users can use ``pgtrigger.Q`` and ``pgtrigger.F`` objects to
 conditionally execute triggers based on the ``OLD`` and ``NEW`` row
-being modified. For example, let's only protect deletes
-against "active" rows of a model:
+being modified.
+
+For example, here we protect deletion of "active" rows of a model:
 
 .. code-block:: python
 
@@ -65,17 +64,19 @@ against "active" rows of a model:
     import pgtrigger
 
 
-    @pgtrigger.register(
-        pgtrigger.Protect(
-            name='conditional_deletion_protection',
-            operation=pgtrigger.Delete,
-            # Protect deletes when the OLD row of the trigger is still active
-            condition=pgtrigger.Q(old__is_active=True)
-        )
-    )
     class CannotBeDeletedModel(models.Model):
         """Active model object cannot be deleted!"""
         is_active = models.BooleanField(default=True)
+
+        class Meta:
+            triggers = [
+                pgtrigger.Protect(
+                    name='protect_deletes',
+                    operation=pgtrigger.Delete,
+                    # Protect deletes when the OLD row of the trigger is still active
+                    condition=pgtrigger.Q(old__is_active=True)
+                )
+            ]
 
 
 Combining ``pgtrigger.Q``, ``pgtrigger.F``, and derived ``pgtrigger.Trigger``

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -42,7 +42,7 @@ Enabling and disabling of triggers can be performed with
 install
 -------
 
-Use ``python manage.py install`` to install triggers. If no arguments are
+Use ``manage.py pgtrigger install`` to install triggers. If no arguments are
 provided, it will try to install all triggers that are not currently installed.
 Messages will be printed for every installed trigger. When executed with
 no arguments, any triggers that were previously installed by ``django-pgtrigger``

--- a/pgtrigger/apps.py
+++ b/pgtrigger/apps.py
@@ -1,6 +1,12 @@
 import django.apps
 from django.conf import settings
+from django.db.models import options
 from django.db.models.signals import post_migrate
+
+
+# Allow triggers to be specified in model Meta options
+if 'triggers' not in options.DEFAULT_NAMES:
+    options.DEFAULT_NAMES = options.DEFAULT_NAMES + ('triggers',)
 
 
 def install(using, **kwargs):
@@ -14,8 +20,18 @@ class PGTriggerConfig(django.apps.AppConfig):
 
     def ready(self):
         """
-        Install pgplus triggers in a post_migrate hook if any are
+        Register all triggers in model Meta and
+        install them in a post_migrate hook if any are
         configured.
         """
+        import pgtrigger
+
+        for model in django.apps.apps.get_models():
+            for trigger in getattr(model._meta, "triggers", []):
+                if not isinstance(trigger, pgtrigger.Trigger):  # pragma: no branch
+                    raise TypeError(f"Triggers in {model} Meta must be pgtrigger.Trigger classes")
+
+                trigger.register(model)
+
         if getattr(settings, 'PGTRIGGER_INSTALL_ON_MIGRATE', True):  # pragma: no branch
             post_migrate.connect(install, sender=self)

--- a/pgtrigger/apps.py
+++ b/pgtrigger/apps.py
@@ -5,7 +5,7 @@ from django.db.models.signals import post_migrate
 
 
 # Allow triggers to be specified in model Meta options
-if 'triggers' not in options.DEFAULT_NAMES:
+if 'triggers' not in options.DEFAULT_NAMES:  # pragma: no branch
     options.DEFAULT_NAMES = options.DEFAULT_NAMES + ('triggers',)
 
 
@@ -28,7 +28,7 @@ class PGTriggerConfig(django.apps.AppConfig):
 
         for model in django.apps.apps.get_models():
             for trigger in getattr(model._meta, "triggers", []):
-                if not isinstance(trigger, pgtrigger.Trigger):  # pragma: no branch
+                if not isinstance(trigger, pgtrigger.Trigger):  # pragma: no cover
                     raise TypeError(f"Triggers in {model} Meta must be pgtrigger.Trigger classes")
 
                 trigger.register(model)

--- a/pgtrigger/core.py
+++ b/pgtrigger/core.py
@@ -62,6 +62,11 @@ def _get_database(model):
     return router.db_for_write(model) or DEFAULT_DB_ALIAS
 
 
+def _postgres_databases(databases):
+    """Given an iterable of databases, only return postgres ones"""
+    return [database for database in databases if connections[database].vendor == 'postgresql']
+
+
 def _get_connection(model):
     """
     Obtains the connection used for a trigger / model pair. The database
@@ -929,7 +934,7 @@ def get_prune_list(database=None):
         databases = database or settings.DATABASES
 
     prune_list = []
-    for database in databases:
+    for database in _postgres_databases(databases):
         with connections[database].cursor() as cursor:
             cursor.execute(
                 'SELECT tgrelid::regclass, tgname, tgenabled'
@@ -1071,7 +1076,7 @@ def install_ignore_func(database=None):
     """
     databases = {_get_database(model) for model, _ in get(database=database)}
 
-    for database in databases:
+    for database in _postgres_databases(databases):
         with connections[database].cursor() as cursor:
             cursor.execute(
                 '''

--- a/pgtrigger/tests/models.py
+++ b/pgtrigger/tests/models.py
@@ -77,16 +77,6 @@ class CharPk(models.Model):
     custom_pk = models.CharField(primary_key=True, max_length=32)
 
 
-@pgtrigger.register(
-    pgtrigger.Protect(name='protect_delete', operation=pgtrigger.Delete),
-    pgtrigger.Trigger(
-        name='protect_misc_insert',
-        when=pgtrigger.Before,
-        operation=pgtrigger.Insert,
-        func="RAISE EXCEPTION 'no no no!';",
-        condition=pgtrigger.Q(new__field='misc_insert'),
-    ),
-)
 class TestTrigger(models.Model):
     """
     For testing triggers
@@ -98,6 +88,18 @@ class TestTrigger(models.Model):
     nullable = models.CharField(null=True, default=None, max_length=16)
     fk_field = models.ForeignKey('auth.User', null=True, on_delete=models.CASCADE)
     char_pk_fk_field = models.ForeignKey(CharPk, null=True, on_delete=models.CASCADE)
+
+    class Meta:
+        triggers = [
+            pgtrigger.Protect(name='protect_delete', operation=pgtrigger.Delete),
+            pgtrigger.Trigger(
+                name='protect_misc_insert',
+                when=pgtrigger.Before,
+                operation=pgtrigger.Insert,
+                func="RAISE EXCEPTION 'no no no!';",
+                condition=pgtrigger.Q(new__field='misc_insert'),
+            ),
+        ]
 
 
 @pgtrigger.register(pgtrigger.SoftDelete(name='soft_delete', field='is_active'))

--- a/pgtrigger/tests/test_multi_db.py
+++ b/pgtrigger/tests/test_multi_db.py
@@ -39,7 +39,7 @@ class ToLogRouter:
 
 @django.test.override_settings(DATABASE_ROUTERS=['pgtrigger.tests.test_multi_db.ToLogRouter'])
 class MultiDB(django.test.TestCase):
-    databases = ['default', 'other']
+    databases = ['default', 'sqlite', 'other']
 
     def setUp(self):
         # Trigger installation is originally executed during

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry>=1.1.13"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 99

--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,7 @@ INSTALLED_APPS = [
 # We have some multi-database tests, so set up two databases
 DATABASES = {
     'default': dj_database_url.config(),
+    'sqlite': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'test_sqlite'},
 }
 DATABASES['other'] = copy.deepcopy(DATABASES['default'])
 if 'NAME' in DATABASES['other']:


### PR DESCRIPTION
Triggers can now be specified with the ``triggers`` attribute of a model's Meta
options. This still works alongside the old method of using ``pgtrigger.register``.

Type: feature

@PaulGilmartin this should make trigger specification a bit cleaner. Although Django doesn't allow one to override model meta options, this seems to be the approach that everyone else takes