### PR TITLE
Fixes ignoring triggers with nested transactions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,3 +120,4 @@ Other Contributors
 
 - @jzmiller1
 - @rrauenza
+- @ralokt


### PR DESCRIPTION
``pgtrigger.ignore`` avoids injecting SQL when transactions are in a failed
state, allowing for one to use nested transactions while ignoring triggers.

Type: bug