### PR TITLE
Added deferrable triggers

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -136,6 +136,17 @@ Referencing clause
 
 .. autoclass:: pgtrigger.Referencing
 
+Timing clause
+-------------
+
+.. autodata:: pgtrigger.Immediate
+  
+  For specifying ``IMMEDIATE`` as the default timing for deferrable triggers
+
+.. autodata:: pgtrigger.Deferred
+
+  For specifying ``DEFERRED`` as the default timing for deferrable triggers
+
 Conditions
 ----------
 .. autoclass:: pgtrigger.Condition

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -108,6 +108,17 @@ triggers.
         The ``REFERENCING`` construct for statement-level triggers is only available
         in Postgres 10 and up.
 
+* **timing** *(optional)*
+
+    Create a deferrable ``CONSTRAINT`` trigger when set. Use `pgtrigger.Immediate` to
+    execute the trigger at the end of a statement and `pgtrigger.Deferred` to execute it
+    at the end of a transaction.
+
+    .. note::
+
+        Deferrable triggers must have the ``level`` set to `pgtrigger.Row` and ``when``
+        set to `pgtrigger.After`.
+
 
 Defining and installing triggers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pgtrigger/__init__.py
+++ b/pgtrigger/__init__.py
@@ -1,37 +1,42 @@
 import django
 
-from pgtrigger.core import After
-from pgtrigger.core import Before
-from pgtrigger.core import Condition
-from pgtrigger.core import Delete
-from pgtrigger.core import disable
-from pgtrigger.core import enable
-from pgtrigger.core import F
-from pgtrigger.core import FSM
-from pgtrigger.core import get
-from pgtrigger.core import ignore
-from pgtrigger.core import Insert
-from pgtrigger.core import install
-from pgtrigger.core import InsteadOf
-from pgtrigger.core import IsDistinctFrom
-from pgtrigger.core import IsNotDistinctFrom
-from pgtrigger.core import Level
-from pgtrigger.core import Operation
-from pgtrigger.core import Operations
-from pgtrigger.core import Protect
-from pgtrigger.core import prune
-from pgtrigger.core import Q
-from pgtrigger.core import Referencing
-from pgtrigger.core import register
-from pgtrigger.core import Row
-from pgtrigger.core import SoftDelete
-from pgtrigger.core import Statement
-from pgtrigger.core import Trigger
-from pgtrigger.core import Truncate
-from pgtrigger.core import uninstall
-from pgtrigger.core import Update
-from pgtrigger.core import UpdateOf
-from pgtrigger.core import When
+from pgtrigger.core import (
+    After,
+    Before,
+    Condition,
+    Deferred,
+    Delete,
+    disable,
+    enable,
+    F,
+    FSM,
+    get,
+    ignore,
+    Immediate,
+    Insert,
+    install,
+    InsteadOf,
+    IsDistinctFrom,
+    IsNotDistinctFrom,
+    Level,
+    Operation,
+    Operations,
+    Protect,
+    prune,
+    Q,
+    Referencing,
+    register,
+    Row,
+    SoftDelete,
+    Statement,
+    Timing,
+    Trigger,
+    Truncate,
+    uninstall,
+    Update,
+    UpdateOf,
+    When,
+)
 from pgtrigger.version import __version__
 
 if django.VERSION < (3, 2):
@@ -44,6 +49,7 @@ __all__ = [
     'After',
     'Before',
     'Condition',
+    'Deferred',
     'Delete',
     'disable',
     'enable',
@@ -51,6 +57,7 @@ __all__ = [
     'FSM',
     'get',
     'ignore',
+    'Immediate',
     'Insert',
     'install',
     'InsteadOf',
@@ -67,6 +74,7 @@ __all__ = [
     'Row',
     'SoftDelete',
     'Statement',
+    'Timing',
     'Trigger',
     'Truncate',
     'uninstall',


### PR DESCRIPTION
Triggers now have an optional ``timing`` argument. If set, triggers
will be created as "CONSTRAINT" triggers that can be deferred.

When ``timing`` is set to ``pgtrigger.Immediate``, the trigger will
run at the end of a statement. ``pgtrigger.Deferred`` will cause
the trigger to run at the end of the transaction.

Note that deferrable triggers must have both
``pgtrigger.After`` and ``pgtrigger.Row`` values set for the
``when`` and ``level`` attributes.

Type: feature

Addresses #14 