### PR TITLE
Add Django 4.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## Pending
+### Feature
+  - Django 4.1 support.
+
 ## 4.3.3 (2022-08-24)
 ### Trivial
   - Fix ReadTheDocs builds [Wes Kendall, 3870643]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ version = "4.3.3"
 description = "Postgres trigger support integrated with Django models."
 authors = ["Wes Kendall"]
 classifiers = [
-  "Intended Audience :: Developers",
+  "Framework :: Django",
+  "Framework :: Django :: 2.2",
+  "Framework :: Django :: 3.2",
+  "Framework :: Django :: 4.0",
+  "Framework :: Django :: 4.1",  "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
 isolated_build = true
-envlist = clean,py37-django32,{38,39,310}-django{22,32,41},report
+envlist =
+    clean
+    py37-django{22,32}
+    py{38,39,310}-django{22,32,40,41}
+    report
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
 whitelist_externals =
     poetry


### PR DESCRIPTION
It looks like testing in this project was possibly accidentally upgraded to 4.1 in 863b8cb53104526945bb4985b316c612c6d4e587. This PR restores testing on 4.0, applies the same fix for python versions, and adds the classifiers, all copied from https://github.com/Opus10/django-pgconnection/pull/13