### PR TITLE
Pruning/installations fixed for Postgres versions 12 and under.

### DIFF
--- a/docs/advanced_db.rst
+++ b/docs/advanced_db.rst
@@ -88,7 +88,7 @@ Partitions
 
 ``django-pgtrigger`` supports tables that use `Postgres table partitioning <https://www.postgresql.org/docs/current/ddl-partitioning.html>`__ with no additional configuration.
 
-
 .. note::
-   Triggers cannot be installed or uninstalled on a per-partition basis. I.e. installing a trigger on a partitioned
+   Row-level triggers are only available for partitioned tables in Postgres 13 and above.
+   Triggers cannot be installed or uninstalled on a per-partition basis. Installing a trigger on a partitioned
    table installs it for all partitions.


### PR DESCRIPTION
Paritioned table support introduced a bug in using trigger management
commands for Postgres 12 and under. This has been fixed.

Type: bug

Addresses #96 