### PR TITLE
Migrations properly serialize dynamic triggers and add better support for reverse migrations

### DIFF
--- a/pgtrigger/compiler.py
+++ b/pgtrigger/compiler.py
@@ -1,0 +1,211 @@
+import collections
+import hashlib
+
+from pgtrigger import utils
+
+
+_unset = object()
+
+
+class UpsertTriggerSql(collections.UserString):
+    """SQL for inserting or updating a trigger
+
+    This class is intended to be versionable since migrations
+    reference it. Older migrations need to be able to point
+    to earlier versions of the installation template used
+    for triggers.
+    """
+
+    def get_template(self):
+        """
+        This is v1 of the installation template. Do NOT edit
+        this template unless you are absolutely sure it is
+        backwards compatible, otherwise it may affect migrations
+        that reference it.
+
+        If it does need to be changed, we will need to introduce
+        a version variable to be backwards compatible.
+
+        Note: Postgres 14 has CREATE OR REPLACE syntax that
+        we might consider using. This SQL is executed in
+        a transaction, so dropping and recreating shouldn't
+        be a problem.
+        """
+        return """
+            CREATE OR REPLACE FUNCTION {ignore_func_name}(
+                trigger_name NAME
+            )
+            RETURNS BOOLEAN AS $$
+                DECLARE
+                    _pgtrigger_ignore TEXT[];
+                    _result BOOLEAN;
+                BEGIN
+                    BEGIN
+                        SELECT INTO _pgtrigger_ignore
+                            CURRENT_SETTING('pgtrigger.ignore');
+                        EXCEPTION WHEN OTHERS THEN
+                    END;
+                    IF _pgtrigger_ignore IS NOT NULL THEN
+                        SELECT trigger_name = ANY(_pgtrigger_ignore)
+                        INTO _result;
+                        RETURN _result;
+                    ELSE
+                        RETURN FALSE;
+                    END IF;
+                END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE OR REPLACE FUNCTION {pgid}()
+            RETURNS TRIGGER AS $$
+                {declare}
+                BEGIN
+                    IF ({ignore_func_name}(TG_NAME) IS TRUE) THEN
+                        IF (TG_OP = 'DELETE') THEN
+                            RETURN OLD;
+                        ELSE
+                            RETURN NEW;
+                        END IF;
+                    END IF;
+                    {func}
+                END;
+            $$ LANGUAGE plpgsql;
+
+            DROP TRIGGER IF EXISTS {pgid} ON {table};
+            CREATE {constraint} TRIGGER {pgid}
+                {when} {operation} ON {table}
+                {timing}
+                {referencing}
+                FOR EACH {level} {condition}
+                EXECUTE PROCEDURE {execute};
+
+            COMMENT ON TRIGGER {pgid} ON {table} IS '{hash}';
+        """
+
+    def get_defaults(self, pgid):
+        """
+        These are the default values for the installation
+        template. Do NOT edit these default values. Keys
+        may be added, but existing keys should never be updated,
+        otherwise existing migrations may no longer be correct.
+
+        If it does need to be changed, we will need to introduce
+        a version variable to be backwards compatible.
+        """
+        return {
+            "ignore_func_name": '"public"._pgtrigger_should_ignore',
+            "declare": "",
+            "constraint": "",
+            "timing": "",
+            "referencing": "",
+            "level": "ROW",
+            "condition": "",
+            "execute": f"{pgid}()",
+        }
+
+    def __init__(
+        self,
+        *,
+        ignore_func_name=_unset,
+        pgid,
+        declare=_unset,
+        func,
+        table,
+        constraint=_unset,
+        when,
+        operation,
+        timing=_unset,
+        referencing=_unset,
+        level=_unset,
+        condition=_unset,
+        execute=_unset,
+        hash=None,
+    ):
+        """Initialize the SQL and store it in the ``.data`` attribute."""
+        self.kwargs = {
+            key: str(val)
+            for key, val in locals().items()
+            if key not in ("self", "hash") and val is not _unset
+        }
+        self.defaults = self.get_defaults(pgid)
+        sql_args = {**self.defaults, **self.kwargs, **{"table": utils.quote(table)}}
+
+        self.hash = (
+            hash
+            or hashlib.sha1(
+                self.get_template().format(**{**sql_args, **{"hash": ""}}).encode()
+            ).hexdigest()
+        )
+        self.data = self.get_template().format(**{**sql_args, **{"hash": self.hash}})
+        self.pgid = pgid
+        self.table = table
+
+    def deconstruct(self):
+        """
+        Serialize the construction of this class so that it can be used in migrations.
+        """
+        kwargs = {
+            key: val for key, val in self.kwargs.items() if self.defaults.get(key, _unset) != val
+        }
+
+        path = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return path, [], {**kwargs, **{"hash": self.hash}}
+
+
+class DropTriggerSql(collections.UserString):
+    """SQL for dropping a trigger
+
+    This class is intended to be versionable since migrations
+    reference it. Older migrations need to be able to point
+    to earlier versions of the installation template used
+    for triggers.
+
+    Note that removing a trigger is very simple, so it's unlikely
+    this class will ever change.
+    """
+
+    def get_template(self):
+        """
+        This is v1 of the removal template. Do NOT edit
+        this template unless you are absolutely sure it is
+        backwards compatible, otherwise it may affect migrations
+        that reference it.
+        """
+        return "DROP TRIGGER IF EXISTS {pgid} ON {table};"
+
+    def __init__(self, *, pgid, table):
+        """Initialize the SQL and store it in the ``.data`` attribute."""
+        sql_args = {**locals(), **{"table": utils.quote(table)}}
+
+        self.data = self.get_template().format(**sql_args)
+
+
+class Trigger:
+    """
+    A compiled trigger that's added to internal model state of migrations. It consists
+    of a name and the trigger SQL.
+    """
+
+    def __init__(self, *, name, sql):
+        self.name = name
+        self.sql = sql
+        assert isinstance(sql, UpsertTriggerSql)
+
+    def __eq__(self, other):
+        return (
+            self.__class__ == other.__class__ and self.name == other.name and self.sql == other.sql
+        )
+
+    @property
+    def install_sql(self):
+        return str(self.sql)
+
+    @property
+    def uninstall_sql(self):
+        return str(DropTriggerSql(pgid=self.sql.pgid, table=self.sql.table))
+
+    def deconstruct(self):
+        """
+        Serialize the construction of this class so that it can be used in migrations.
+        """
+        path = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return path, [], {"name": self.name, "sql": self.sql}

--- a/pgtrigger/tests/test_core.py
+++ b/pgtrigger/tests/test_core.py
@@ -154,7 +154,16 @@ def test_declaration_rendering():
     rendered = DeclaredTrigger(
         name="test", when=pgtrigger.Before, operation=pgtrigger.Insert
     ).render_declare(None)
-    assert rendered == "DECLARE \nvar_name UUID;"
+    assert rendered == "DECLARE var_name UUID;"
+
+    class DeclaredTriggerMultiple(pgtrigger.Trigger):
+        def get_declare(self, model):
+            return [("var_name", "UUID"), ("var2_name", "UUID")]
+
+    rendered = DeclaredTriggerMultiple(
+        name="test", when=pgtrigger.Before, operation=pgtrigger.Insert
+    ).render_declare(None)
+    assert rendered == "DECLARE var_name UUID; var2_name UUID;"
 
 
 def test_f():


### PR DESCRIPTION
Triggers that override ``get_func`` or otherwise generate dynamic SQL are properly reflected
in migrations when the underlying implementation changes. Along with this, migrations now serialize
SQL objects instead of trigger classes, making it more robust when reversing migrations or
updating underlying implementations of existing triggers.

This change updates the hashes of all triggers and thus re-creates all triggers when running
``makemigrations`` or when manually installing them.

Type: bug

Addresses #91 