### PR TITLE
Added ``ReadOnly`` trigger for uneditable models and fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ dependencies:
 
 
 .PHONY: multi-db-setup
-db-setup:
+multi-db-setup:
 	-$(DOCKER_EXEC_WRAPPER) psql $(DATABASE_URL) -c "CREATE DATABASE postgres_other WITH TEMPLATE postgres"
 	$(DOCKER_EXEC_WRAPPER) psql $(DATABASE_URL) -c "CREATE SCHEMA IF NOT EXISTS \"order\""
 	$(DOCKER_EXEC_WRAPPER) psql $(DATABASE_URL) -c "CREATE SCHEMA IF NOT EXISTS receipt;"

--- a/README.rst
+++ b/README.rst
@@ -11,15 +11,16 @@ Why should I use triggers?
 Triggers can solve a variety of complex problems more reliably, performantly, and succinctly than application code.
 For example,
 
-1. Protecting operations on rows or columns (``pgtrigger.Protect``).
-2. Soft-deleting models (``pgtrigger.SoftDelete``).
-3. Snapshotting and tracking model changes (`django-pghistory <https://django-pghistory.readthedocs.io/>`__).
-4. Enforcing field transitions (``pgtrigger.FSM``).
-5. Keeping a search vector updated for full-text search (``pgtrigger.UpdateSearchVector``).
-6. Building official interfaces
-   (e.g. enforcing use of ``User.objects.create_user`` and not
-   ``User.objects.create``).
-7. Versioning models, mirroring fields, computing unique model hashes, and the list goes on...
+* Protecting operations on rows or columns (``pgtrigger.Protect``).
+* Making read-only models or fields (``pgtrigger.ReadOnly``).
+* Soft-deleting models (``pgtrigger.SoftDelete``).
+* Snapshotting and tracking model changes (`django-pghistory <https://django-pghistory.readthedocs.io/>`__).
+* Enforcing field transitions (``pgtrigger.FSM``).
+* Keeping a search vector updated for full-text search (``pgtrigger.UpdateSearchVector``).
+* Building official interfaces
+  (e.g. enforcing use of ``User.objects.create_user`` and not
+  ``User.objects.create``).
+* Versioning models, mirroring fields, computing unique model hashes, and the list goes on...
 
 All of these examples require no overridden methods, no base models, and no signal handling.
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -8,6 +8,42 @@ Here we provide examples using the built-in triggers of
 examples are practical application examples, some exist to illustrate
 a starting point of how one can use triggers for more complex cases.
 
+Read-only models and fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ensure a set of fields on a model are read-only with
+`pgtrigger.ReadOnly`. This trigger takes one of the following
+optional arguments:
+
+* **fields**: A list of read-only fields.
+* **exclude**: Fields to exclude. All other fields will be
+  read-only.
+
+If no arguments are provided, the entire model will be read-only.
+
+For example, here we have a model with a read-only ``created_at``
+timestamp. Any changes to this field will result in an exception:
+
+.. code-block:: python
+
+    class TimestampedModel(models.Model):
+        """Ensure created_at timestamp is read only"""
+        created_at = models.DateTimeField(auto_now_add=True)
+        editable_value = models.TextField()
+
+        class Meta:
+            triggers = [
+                pgtrigger.ReadOnly(
+                    name="read_only_created_at",
+                    fields=["created_at"]
+                )
+            ]
+
+.. note::
+
+    A condition is automatically generated and cannot be supplied
+    to `pgtrigger.ReadOnly`.
+
 Validating field transitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,15 +11,16 @@ Why should I use triggers?
 Triggers can solve a variety of complex problems more reliably, performantly, and succinctly than application code.
 For example,
 
-1. Protecting operations on rows or columns (`pgtrigger.Protect`).
-2. Soft-deleting models (`pgtrigger.SoftDelete`).
-3. Snapshotting and tracking model changes (`django-pghistory <https://django-pghistory.readthedocs.io>`__).
-4. Enforcing field transitions (`pgtrigger.FSM`).
-5. Keeping a search vector updated for full-text search (`pgtrigger.UpdateSearchVector`).
-6. Building official interfaces
-   (e.g. enforcing use of ``User.objects.create_user`` and not
-   ``User.objects.create``).
-7. Versioning models, mirroring fields, computing unique model hashes, and the list goes on...
+* Protecting operations on rows or columns (`pgtrigger.Protect`).
+* Making read-only models or fields (`pgtrigger.ReadOnly`).
+* Soft-deleting models (`pgtrigger.SoftDelete`).
+* Snapshotting and tracking model changes (`django-pghistory <https://django-pghistory.readthedocs.io>`__).
+* Enforcing field transitions (`pgtrigger.FSM`).
+* Keeping a search vector updated for full-text search (`pgtrigger.UpdateSearchVector`).
+* Building official interfaces
+  (e.g. enforcing use of ``User.objects.create_user`` and not
+  ``User.objects.create``).
+* Versioning models, mirroring fields, computing unique model hashes, and the list goes on...
 
 All of these examples require no overridden methods, no base models, and no signal handling.
 

--- a/docs/module.rst
+++ b/docs/module.rst
@@ -78,6 +78,7 @@ Triggers
 --------
 .. autoclass:: pgtrigger.Trigger
 .. autoclass:: pgtrigger.Protect
+.. autoclass:: pgtrigger.ReadOnly
 .. autoclass:: pgtrigger.SoftDelete
 .. autoclass:: pgtrigger.FSM
 .. autoclass:: pgtrigger.UpdateSearchVector

--- a/pgtrigger/__init__.py
+++ b/pgtrigger/__init__.py
@@ -3,6 +3,7 @@ import django
 from pgtrigger.contrib import (
     FSM,
     Protect,
+    ReadOnly,
     SoftDelete,
     UpdateSearchVector,
 )
@@ -82,6 +83,7 @@ __all__ = [
     "prunable",
     "prune",
     "Q",
+    "ReadOnly",
     "Referencing",
     "register",
     "registered",


### PR DESCRIPTION
The ``pgtrigger.ReadOnly`` trigger protects updates on models and takes an optional ``fields`` or ``exclude`` argument to specify which fields are read only. If no arguments are provided, the entire model is read only.

Type: feature