### PR TITLE
Create triggers for tables in unmigrated apps when run_syncdb is specified

### DIFF
--- a/pgtrigger/tests/test_migrations.py
+++ b/pgtrigger/tests/test_migrations.py
@@ -305,6 +305,20 @@ def test_makemigrations_create_remove_models(settings):
     with pytest.raises(ProgrammingError):
         protected_model.delete()
 
+    # Unapply migration where a model with a trigger is removed
+    # Any triggers that were defined on the model when it was removed should be
+    # recreated.
+    call_command("migrate", "tests", str(num_expected_migrations - 1).rjust(4, "0"))
+
+    test_models.DynamicTestModel = DynamicTestModel
+    protected_model = ddf.G(test_models.DynamicTestModel)
+    with utils.raises_trigger_error(match="Cannot delete"):
+        protected_model.delete()
+    del test_models.DynamicTestModel
+
+    # Reapply the migration we just unapplied
+    call_command("migrate")
+
     # Create a new proxy model on a third-party app and add it to the test models
     class DynamicProxyModel(auth_models.User):
         class Meta:

--- a/pgtrigger/tests/test_syncdb.py
+++ b/pgtrigger/tests/test_syncdb.py
@@ -1,0 +1,37 @@
+from django.db import connection
+import pytest
+
+from pgtrigger.tests import utils
+import pgtrigger.tests.test_syncdb_app.models as syncdb_models
+
+
+# Adapted from django's tests/schema/tests.py
+def delete_tables(models):
+    "Deletes all model tables for our models for a clean test environment"
+    converter = connection.introspection.identifier_converter
+    with connection.schema_editor() as editor:
+        connection.disable_constraint_checking()
+        table_names = connection.introspection.table_names()
+        for model in models:
+            tbl = converter(model._meta.db_table)
+            if tbl in table_names:
+                editor.delete_model(model)
+                table_names.remove(tbl)
+        connection.enable_constraint_checking()
+
+
+@pytest.mark.django_db
+def test_create_model_creates_triggers():
+    """create_model is called when the django app doesn't have a migrations module.
+    create_model is also called during a `CreateTable` migration operation
+    but as the triggers aren't stored with the CreateTable operation, the
+    specific code that creates triggers in `create_model` isn't executed.
+    """
+    delete_tables([syncdb_models.NoMigrationModel])
+    try:
+        with connection.schema_editor() as editor:
+            editor.create_model(syncdb_models.NoMigrationModel)
+        with utils.raises_trigger_error(match="no no no!"):
+            syncdb_models.NoMigrationModel.objects.create(field="misc_insert", int_field=1)
+    finally:
+        delete_tables([syncdb_models.NoMigrationModel])

--- a/pgtrigger/tests/test_syncdb_app/apps.py
+++ b/pgtrigger/tests/test_syncdb_app/apps.py
@@ -1,0 +1,5 @@
+import django.apps
+
+
+class PGTriggerSyncdbTestsConfig(django.apps.AppConfig):
+    name = "pgtrigger.tests.test_syncdb_app"

--- a/pgtrigger/tests/test_syncdb_app/models.py
+++ b/pgtrigger/tests/test_syncdb_app/models.py
@@ -1,0 +1,31 @@
+from django.apps.registry import Apps
+from django.db import models
+from django.utils import timezone
+
+import pgtrigger
+
+
+syncdb_apps = Apps()
+
+
+class NoMigrationModel(models.Model):
+    """
+    For testing triggers
+    """
+
+    field = models.CharField(max_length=16)
+    int_field = models.IntegerField(default=0)
+    dt_field = models.DateTimeField(default=timezone.now)
+    nullable = models.CharField(null=True, default=None, max_length=16)
+
+    class Meta:
+        apps = syncdb_apps
+        triggers = [
+            pgtrigger.Trigger(
+                name="protect_misc_insert",
+                when=pgtrigger.Before,
+                operation=pgtrigger.Insert,
+                func="RAISE EXCEPTION 'no no no!';",
+                condition=pgtrigger.Q(new__field="misc_insert"),
+            ),
+        ]

--- a/settings.py
+++ b/settings.py
@@ -19,7 +19,10 @@ INSTALLED_APPS = [
 # Conditionally add the test app when we aren't building docs,
 # otherwise sphinx builds won't work
 if not os.environ.get("SPHINX"):
-    INSTALLED_APPS += ["pgtrigger.tests"]
+    INSTALLED_APPS += [
+        "pgtrigger.tests",
+        "pgtrigger.tests.test_syncdb_app",
+    ]
 
 # Database url comes from the DATABASE_URL env var
 # We have some multi-database and multi-schema tests


### PR DESCRIPTION
Implements https://github.com/Opus10/django-pgtrigger/issues/112

It creates the triggers in `DatabaseSchemaEditorMixin.create_model` by creating any triggers defined in the models `Meta.triggers` attribute. The triggers should only be created here if we're doing a 'run_syncdb' operation on an unmigrated app. `create_model` is also called during a CreateTable migration operation too, but given the logic in MigrationAutodetectorMixin above, the initial state of the table used in the `CreateTable` operation won't have any `triggers` attribute yet. The `triggers` attibute only gets added to the model's migration state with an `AddTrigger` operation after the initial `CreateTable` operation.
