### PR TITLE
Use nullcontext if migration is not atomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ ifndef run
 	      "    dependencies: Install dependencies\n"\
 	      "    shell: Start a shell\n"\
 	      "    test: Run tests\n"\
+		  "    test-independent: Run tests marked as independent\n"\
 	      "    tox: Run tests against all versions of Python\n"\
 	      "    lint: Run code linting and static checks\n"\
 	      "    lint-fix: Fix common linting errors\n"\
@@ -141,6 +142,12 @@ shell:
 .PHONY: test
 test:
 	$(EXEC_WRAPPER) pytest
+
+
+# Run pytest
+.PHONY: test-independent
+test-independent:
+	$(EXEC_WRAPPER) pytest -m independent
 
 
 # Run full test suite

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ class ProtectedModel(models.Model):
 
 Triggers are installed like other database objects. Run `python manage.py makemigrations` and `python manage.py migrate` to install triggers.
 
+**Note** that if a migration is altering field type, by design django-pgtriggers drops trigger before the operations start and recreate it afterwards. Be aware of that if you create a non-atomic migration.
+
 If triggers are new to you, don't worry. The [pgtrigger docs](https://django-pgtrigger.readthedocs.io/) cover triggers in more detail and provide many examples.
 
 ## Compatibility

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 version: "3.3"
-   
+
 services:
   db:
     image: cimg/postgres:14.4


### PR DESCRIPTION
This solves an issue #132

Type: bug