### PR TITLE
Fixes #126 Pass app label, model name into _inject_m2m_depenency_in_proxy

### DIFF
--- a/pgtrigger/migrations.py
+++ b/pgtrigger/migrations.py
@@ -133,13 +133,13 @@ class RemoveTrigger(TriggerOperationMixin, IndexOperation):
         return f"remove_{self.model_name_lower}_{self.name.lower()}"
 
 
-def _inject_m2m_dependency_in_proxy(proxy_op):
+def _inject_m2m_dependency_in_proxy(proxy_op, app_label, model_name):
     """
     Django does not properly add dependencies to m2m fields that are base classes for
     proxy models. Inject the dependency here
     """
     for base in proxy_op.bases:
-        model = apps.get_model(base)
+        model = apps.get_model(app_label, model_name)
         creator = model._meta.auto_created
         if creator:
             for field in creator._meta.many_to_many:
@@ -255,7 +255,7 @@ class MigrationAutodetectorMixin:
                 if isinstance(op, CreateModel) and op.options.get(  # pragma: no branch
                     "proxy", False
                 ):
-                    _inject_m2m_dependency_in_proxy(op)
+                    _inject_m2m_dependency_in_proxy(op, app_label, model_name)
 
             model = self.to_state.apps.get_model(app_label, model_name)
             model_state = self.to_state.models[app_label, model_name]


### PR DESCRIPTION
Hi, I'll try and provide a minimum breaking example to make it easy to verify that this works correctly in a bit. Fixes #126 

django's implementation of generate_created_proxies uses the project state to create the operations. Prior to this commit apps.get_model, since no app_label and model_name were provided, get_model would assume that `base` was a string. If a model mixin was used, a class would be passed in instead resulting in a

    AttributeError: type object 'SomeMixin' has no attribute 'split'

By explicitly passing in the app_label and model_name, this line https://github.com/django/django/blob/main/django/apps/registry.py#L205-L206

is skipped and the migrations are generated as normal.