### PR TITLE
Add Django 5.1 compatibility to MigrationAutodetectorMixin

### DIFF
--- a/pgtrigger/migrations.py
+++ b/pgtrigger/migrations.py
@@ -1,12 +1,21 @@
 import contextlib
 import re
 
+from django import __version__ as DJANGO_VERSION
 from django.apps import apps
 from django.db import transaction
 from django.db.migrations.operations.fields import AddField
 from django.db.migrations.operations.models import CreateModel, IndexOperation
 
 from pgtrigger import compiler, utils
+
+if DJANGO_VERSION >= "5.1":
+    from django.db.migrations.autodetector import OperationDependency
+
+    OPERATION_DEPENDENCY_CREATE = OperationDependency.Type.CREATE
+else:
+    OperationDependency = lambda *args: tuple((args))  # noqa: E731
+    OPERATION_DEPENDENCY_CREATE = True
 
 
 def _add_trigger(schema_editor, model, trigger):
@@ -145,7 +154,11 @@ def _inject_m2m_dependency_in_proxy(proxy_op):
             for field in creator._meta.many_to_many:
                 if field.remote_field.through == model:
                     app_label, model_name = creator._meta.label_lower.split(".")
-                    proxy_op._auto_deps.append((app_label, model_name, field.name, True))
+                    proxy_op._auto_deps.append(
+                        OperationDependency(
+                            app_label, model_name, field.name, OPERATION_DEPENDENCY_CREATE
+                        )
+                    )
 
 
 class MigrationAutodetectorMixin:
@@ -230,10 +243,13 @@ class MigrationAutodetectorMixin:
             }
 
             related_dependencies = [
-                (app_label, model_name, name, True) for name in sorted(related_fields)
+                OperationDependency(app_label, model_name, name, OPERATION_DEPENDENCY_CREATE)
+                for name in sorted(related_fields)
             ]
             # Depend on the model being created
-            related_dependencies.append((app_label, model_name, None, True))
+            related_dependencies.append(
+                OperationDependency(app_label, model_name, None, OPERATION_DEPENDENCY_CREATE)
+            )
 
             for trigger in model_state.options.pop("triggers", []):
                 self.add_operation(
@@ -265,7 +281,11 @@ class MigrationAutodetectorMixin:
                 self.add_operation(
                     app_label,
                     self._get_add_trigger_op(model=model, trigger=trigger),
-                    dependencies=[(app_label, model_name, None, True)],
+                    dependencies=[
+                        OperationDependency(
+                            app_label, model_name, None, OPERATION_DEPENDENCY_CREATE
+                        )
+                    ],
                 )
 
     def generate_deleted_proxies(self):
@@ -278,7 +298,11 @@ class MigrationAutodetectorMixin:
                 self.add_operation(
                     app_label,
                     RemoveTrigger(model_name=model_name, name=trigger.name),
-                    dependencies=[(app_label, model_name, None, True)],
+                    dependencies=[
+                        OperationDependency(
+                            app_label, model_name, None, OPERATION_DEPENDENCY_CREATE
+                        )
+                    ],
                 )
 
         super().generate_deleted_proxies()

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     py312-django42-psycopg3
     py{310,311,312}-django50-psycopg2
     py312-django50-psycopg3
+    py{310,311,312}-django51-psycopg2
+    py312-django51-psycopg3
     report
 
 [testenv]
@@ -22,6 +24,7 @@ deps =
     django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
     django50: Django>=5.0rc1,<5.1
+    django51: Django>=5.1rc1,<5.2
     psycopg2: psycopg2-binary
     psycopg3: psycopg[binary]
 commands =


### PR DESCRIPTION
Thanks to #148 I managed to find a fix to make pg-trigger compatible with Django 5.1

> Django 5.1 switched to [namedtuples for migration dependencies](https://github.com/django/django/commit/7dd3e694db17bc34f9ce73e516f853ebd16e19e7).
> 
> pgtrigger's [migration patching will also need to be updated 👍](https://github.com/Opus10/django-pgtrigger/blob/3c2669bfb97500fc53edeefa981fa74da5412067/pgtrigger/migrations.py#L148)

NB: It would be nice to add Django "main" version to the testing grid so that issue are discovered soon enough before the official releases