### PR TITLE
Account for execute result being `None`

### DIFF
--- a/pgtrigger/runtime.py
+++ b/pgtrigger/runtime.py
@@ -75,7 +75,7 @@ def _can_inject_variable(cursor, sql):
 
 def _execute_wrapper(execute_result):
     if utils.psycopg_maj_version == 3:
-        while execute_result.nextset():
+        while execute_result is not None and execute_result.nextset():
             pass
     return execute_result
 


### PR DESCRIPTION
Account for `execute_result` being `None` as was done in pghistory: https://github.com/Opus10/django-pghistory/pull/156

Fixes https://github.com/Opus10/django-pgtrigger/issues/169